### PR TITLE
Issue #346: Many fixes

### DIFF
--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Helper/Factory.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Helper/Factory.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use LizardsAndPumpkins\MagentoConnector\Api\Api;
+use LizardsAndPumpkins\MagentoConnector\Api\GuzzleHttpApiClient;
 use LizardsAndPumpkins\MagentoConnector\Images\ImageLinker;
 use LizardsAndPumpkins\MagentoConnector\Images\ImagesCollector;
 use LizardsAndPumpkins\MagentoConnector\XmlBuilder\CatalogMerge;
@@ -181,5 +183,16 @@ class LizardsAndPumpkins_MagentoConnector_Helper_Factory
     private function getCategoryCollection()
     {
         return Mage::getResourceSingleton('lizardsAndPumpkins_magentoconnector/catalog_category_collection');
+    }
+
+    /**
+     * @return Api
+     */
+    public function createLizardsAndPumpkinsApi()
+    {
+        return new Api(
+            Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url'),
+            new GuzzleHttpApiClient()
+        );
     }
 }

--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Export/AbstractCategoryCollector.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Export/AbstractCategoryCollector.php
@@ -91,7 +91,9 @@ abstract class LizardsAndPumpkins_MagentoConnector_Model_Export_AbstractCategory
                 }, $ancestorIds);
 
                 $urlPath = array_filter($categoryIdsReplacedWithUrlKeys);
-                $category->setData('url_path', implode('/', $urlPath) . $this->config->getCategoryUrlSuffix());
+                $categoryUrlSuffix = $this->config->getCategoryUrlSuffix();
+                if ($categoryUrlSuffix[0] !== '.') $categoryUrlSuffix = '.' . $categoryUrlSuffix;
+                $category->setData('url_path', implode('/', $urlPath) . $categoryUrlSuffix);
             } catch (RuntimeException $e) {
                 if ($e->getCode() === 404) {
                     unset($category);

--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Export/Content.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Export/Content.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use LizardsAndPumpkins\MagentoConnector\Api\Api;
+use LizardsAndPumpkins\MagentoConnector\Api\GuzzleHttpApiClient;
 
 class LizardsAndPumpkins_MagentoConnector_Model_Export_Content
 {
@@ -87,7 +88,7 @@ class LizardsAndPumpkins_MagentoConnector_Model_Export_Content
     {
         if (null === $this->memoizedApi) {
             $apiUrl = Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url');
-            $this->memoizedApi = new Api($apiUrl);
+            $this->memoizedApi = new Api($apiUrl, new GuzzleHttpApiClient());
         }
 
         return $this->memoizedApi;

--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Export/Content.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Export/Content.php
@@ -87,8 +87,9 @@ class LizardsAndPumpkins_MagentoConnector_Model_Export_Content
     private function getApi()
     {
         if (null === $this->memoizedApi) {
-            $apiUrl = Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url');
-            $this->memoizedApi = new Api($apiUrl, new GuzzleHttpApiClient());
+            /** @var \LizardsAndPumpkins_MagentoConnector_Helper_Factory $helper */
+            $helper = Mage::helper('lizardsAndPumpkins_magentoconnector/factory');
+            $this->memoizedApi = $helper->createLizardsAndPumpkinsApi();
         }
 
         return $this->memoizedApi;

--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Resource/Catalog/Product/Collection.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Resource/Catalog/Product/Collection.php
@@ -684,7 +684,7 @@ class LizardsAndPumpkins_MagentoConnector_Model_Resource_Catalog_Product_Collect
             return '';
         }
 
-        $options = array_values($this->getEavAttributeOptions($attributeId));
+        $options = $this->getEavAttributeOptions($attributeId);
 
         if ([] === $options) {
             return $rawValue;

--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Resource/Catalog/Product/Collection.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/Model/Resource/Catalog/Product/Collection.php
@@ -217,12 +217,17 @@ class LizardsAndPumpkins_MagentoConnector_Model_Resource_Catalog_Product_Collect
     private function getUrlKey(array $productData)
     {
         static $productUrlKeySuffix;
+        
+        if (isset($productData['url_path'])) {
+            return $productData['url_path'];
+        }
+        
         $storeId = $this->getStoreId();
         if (is_null($productUrlKeySuffix) || !isset($productUrlKeySuffix[$storeId])) {
             $productUrlKeySuffix[$storeId] = Mage::getStoreConfig('catalog/seo/product_url_suffix', $storeId);
         }
         return isset($productData['url_key']) && $productUrlKeySuffix[$storeId] ?
-            $productData['url_key'] . $productUrlKeySuffix[$storeId] :
+            $productData['url_key'] . '.' . $productUrlKeySuffix[$storeId] :
             'catalog/product/view/id/' . $productData['entity_id'];
     }
 
@@ -441,9 +446,10 @@ class LizardsAndPumpkins_MagentoConnector_Model_Resource_Catalog_Product_Collect
     private function getCategoryUrlPathsForId($categoryId)
     {
         $categoryUrlKeys = $this->getCategoryUrlKeysForId($categoryId);
-        $suffix = Mage::getStoreConfig('catalog/seo/category_url_suffix', $this->getStoreId());
-        return array_map(function ($urlKey) use ($suffix) {
-            return $urlKey . $suffix;
+        $urlSuffix = Mage::getStoreConfig('catalog/seo/category_url_suffix', $this->getStoreId());
+        $urlSuffix = '.' === $urlSuffix[0] ? $urlSuffix : '.' . $urlSuffix;
+        return array_map(function ($urlKey) use ($urlSuffix) {
+            return $urlKey . $urlSuffix;
         }, $categoryUrlKeys);
     }
 

--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/controllers/Adminhtml/LizardsAndPumpkins/VersionController.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/controllers/Adminhtml/LizardsAndPumpkins/VersionController.php
@@ -21,10 +21,13 @@ class LizardsAndPumpkins_MagentoConnector_Adminhtml_LizardsAndPumpkins_VersionCo
         Api $api = null
     ) {
         parent::__construct($request, $response, $invokeArgs);
-        $this->api = $api ?? new Api(
-                Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url'),
-                new GuzzleHttpApiClient()
-            );
+        if ($api) {
+            $this->api = $api;
+        } else {
+            /** @var \LizardsAndPumpkins_MagentoConnector_Helper_Factory $helper */
+            $helper = Mage::helper('lizardsAndPumpkins_magentoconnector/factory');
+            $this->api = $helper->createLizardsAndPumpkinsApi();
+        }
     }
 
     public function indexAction()

--- a/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/controllers/Adminhtml/LizardsAndPumpkinsController.php
+++ b/magento-plugin/app/code/community/LizardsAndPumpkins/MagentoConnector/controllers/Adminhtml/LizardsAndPumpkinsController.php
@@ -79,7 +79,8 @@ class LizardsAndPumpkins_MagentoConnector_Adminhtml_LizardsAndPumpkinsController
      */
     private function triggerCatalogUpdateApi($filename)
     {
-        $apiUrl = Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url');
-        (new Api($apiUrl))->triggerProductImport($filename);
+        /** @var \LizardsAndPumpkins_MagentoConnector_Helper_Factory $helper */
+        $helper = Mage::helper('lizardsAndPumpkins_magentoconnector/factory');
+        $helper->createLizardsAndPumpkinsApi()->triggerProductImport($filename);
     }
 }

--- a/magento-plugin/shell/lizards_and_pumpkins_export.php
+++ b/magento-plugin/shell/lizards_and_pumpkins_export.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use LizardsAndPumpkins\MagentoConnector\Api\Api;
+use LizardsAndPumpkins\MagentoConnector\Api\GuzzleHttpApiClient;
 
 require __DIR__ . '/../../vendor/autoload.php';
 require 'abstract.php';
@@ -63,7 +64,7 @@ class LizardsAndPumpkins_Export extends Mage_Shell_Abstract
             return;
         }
         $apiUrl = Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url');
-        (new Api($apiUrl))->triggerProductImport($filename);
+        (new Api($apiUrl, new GuzzleHttpApiClient()))->triggerProductImport($filename);
     }
 
     /**

--- a/magento-plugin/shell/lizards_and_pumpkins_export.php
+++ b/magento-plugin/shell/lizards_and_pumpkins_export.php
@@ -63,8 +63,9 @@ class LizardsAndPumpkins_Export extends Mage_Shell_Abstract
         if (!$this->catalogExporter->wasSomethingExported()) {
             return;
         }
-        $apiUrl = Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url');
-        (new Api($apiUrl, new GuzzleHttpApiClient()))->triggerProductImport($filename);
+        /** @var \LizardsAndPumpkins_MagentoConnector_Helper_Factory $helper */
+        $helper = Mage::helper('lizardsAndPumpkins_magentoconnector/factory');
+        $helper->createLizardsAndPumpkinsApi()->triggerProductImport($filename);
     }
 
     /**

--- a/pollExportQueue.php
+++ b/pollExportQueue.php
@@ -22,8 +22,9 @@ class PollsExportQueue
             $filename = $exporter->exportProductsInQueue();
             if ($exporter->wasSomethingExported()) {
                 sleep(10);
-                $apiUrl = Mage::getStoreConfig('lizardsAndPumpkins/magentoconnector/api_url');
-                (new Api($apiUrl))->triggerProductImport($filename);
+                /** @var \LizardsAndPumpkins_MagentoConnector_Helper_Factory $helper */
+                $helper = Mage::helper('lizardsAndPumpkins_magentoconnector/factory');
+                $helper->createLizardsAndPumpkinsApi()->triggerProductImport($filename);
             }
 
             usleep(self::$sleepMicroSeconds);

--- a/tests/Integration/Suites/Helper/FactoryTest.php
+++ b/tests/Integration/Suites/Helper/FactoryTest.php
@@ -1,0 +1,14 @@
+<?php
+
+class FactoryTest extends \PHPUnit\Framework\TestCase
+{
+    public function testReturnsLizardsAndPumpkinsApi()
+    {
+        Mage::app()->getStore()->setConfig('lizardsAndPumpkins/magentoconnector/api_url', 'http://example.com');
+        
+        /** @var \LizardsAndPumpkins_MagentoConnector_Helper_Factory $helper */
+        $helper = Mage::helper('lizardsAndPumpkins_magentoconnector/factory');
+        $result = $helper->createLizardsAndPumpkinsApi();
+        $this->assertInstanceOf(\LizardsAndPumpkins\MagentoConnector\Api\Api::class, $result);
+    }
+}

--- a/tests/Integration/Suites/Model/Export/SpecificCategoryCollectorTest.php
+++ b/tests/Integration/Suites/Model/Export/SpecificCategoryCollectorTest.php
@@ -8,11 +8,13 @@ class LizardsAndPumpkins_MagentoConnector_Model_Export_SpecificCategoryCollector
         $config = new LizardsAndPumpkins_MagentoConnector_Model_Export_MagentoConfig();
         $categoryUrlPathSuffix = Mage::getStoreConfig(Mage_Catalog_Helper_Category::XML_PATH_CATEGORY_URL_SUFFIX);
         
+        $expectedSuffix = '.' === $categoryUrlPathSuffix[0] ? $categoryUrlPathSuffix : '.' . $categoryUrlPathSuffix;
+        
         $categoryCollector = new LizardsAndPumpkins_MagentoConnector_Model_Export_SpecificCategoryCollector($config);
         
         $categoryCollector->setCategoryIdsToExport([4]);
         
         $category = $categoryCollector->getCategory();
-        $this->assertStringEndsWith('.' . $categoryUrlPathSuffix, $category->getData('url_path'));
+        $this->assertStringEndsWith($expectedSuffix, $category->getData('url_path'));
     }
 }

--- a/tests/Integration/Suites/Model/Export/SpecificCategoryCollectorTest.php
+++ b/tests/Integration/Suites/Model/Export/SpecificCategoryCollectorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+class LizardsAndPumpkins_MagentoConnector_Model_Export_SpecificCategoryCollectorTest
+    extends \PHPUnit\Framework\TestCase
+{
+    public function testCategoryUrlKeySuffixIsAppendedSeparatedByADot()
+    {
+        $config = new LizardsAndPumpkins_MagentoConnector_Model_Export_MagentoConfig();
+        $categoryUrlPathSuffix = Mage::getStoreConfig(Mage_Catalog_Helper_Category::XML_PATH_CATEGORY_URL_SUFFIX);
+        
+        $categoryCollector = new LizardsAndPumpkins_MagentoConnector_Model_Export_SpecificCategoryCollector($config);
+        
+        $categoryCollector->setCategoryIdsToExport([4]);
+        
+        $category = $categoryCollector->getCategory();
+        $this->assertStringEndsWith('.' . $categoryUrlPathSuffix, $category->getData('url_path'));
+    }
+}

--- a/tests/Integration/Suites/Model/Resource/Catalog/Product/CollectionTest.php
+++ b/tests/Integration/Suites/Model/Resource/Catalog/Product/CollectionTest.php
@@ -37,6 +37,7 @@ class LizardsAndPumpkins_MagentoConnector_Model_Resource_Catalog_Product_Collect
 
     public function testIncludesProductInCategoryUrlKeysAsNonCanonicalUrlKeys()
     {
+        $this->collection->setStore(1);
         $this->collection->setPageSize(25);
         $this->collection->setFlag(
             LizardsAndPumpkins_MagentoConnector_Model_Resource_Catalog_Product_Collection::FLAG_ADD_CATEGORY_IDS,

--- a/tests/Integration/Suites/Model/Resource/Catalog/Product/CollectionTest.php
+++ b/tests/Integration/Suites/Model/Resource/Catalog/Product/CollectionTest.php
@@ -125,4 +125,13 @@ class LizardsAndPumpkins_MagentoConnector_Model_Resource_Catalog_Product_Collect
             $this->assertSame('catalog/product/view/id/' . $productData['entity_id'], $productData['url_key']);
         }
     }
+
+    public function testSetsTheCorrectTaxClassOnProducts()
+    {
+        $this->collection->setPageSize(10);
+
+        foreach ($this->collection->getData() as $productData) {
+            $this->assertSame('Taxable Goods', $productData['tax_class']);
+        }
+    }
 }


### PR DESCRIPTION
* Add missing parameters to Api constructor calls.
* Add Magento 1.9.3.x URL key suffix handling compatibility.
* Export the correct tax class on products.

All changes covered by tests.